### PR TITLE
Fix handling of enclitics in word tokenizer

### DIFF
--- a/cltk/tokenize/word.py
+++ b/cltk/tokenize/word.py
@@ -1,11 +1,15 @@
-"""Language-specific word tokenizers. Primary purpose is to handle enclitics."""
+"""Language-specific word tokenizers. Primary purpose is to handle enclitics.
+-----
+Re: latin
+Starter lists have been included to handle the Latin enclitics (-que, -ne, -ue/-ve, -cum). These lists are based on high-frequency vocabulary and have been supplemented on a as-needed basis; i.e. they are not comprehensive. Additions to the exceptions list are welcome. PJB
+-----
+"""
 
 __author__ = ['Patrick J. Burns <patrick@diyclassics.org>',
               'Kyle P. Johnson <kyle@kyle-p-johnson.com>']
 __license__ = 'MIT License. See LICENSE.'
 
 from nltk.tokenize.punkt import PunktLanguageVars
-
 
 class WordTokenizer:  # pylint: disable=too-few-public-methods
     """Tokenize according to rules specific to a given language."""
@@ -18,18 +22,39 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
             "Specific tokenizer not available for '{0}'. Only available for: '{1}'.".format(self.language, self.available_languages)  # pylint: disable=line-too-long
 
         if self.language == 'latin':
-            #self.enclitics = ['que', 've', 'ne']
-            self.enclitics = ['que']
-            # Patrick's excpetions
-            self.exceptions = ['atque', 'neque', 'quoque', 'itaque', 'usque', 'denique', 'quisque', 'namque', 'quinque', 'utique', 'quaeque', 'plerumque', 'utrumque', 'aeque', 'undique', 'utraque', 'cumque', 'cuique', 'plerique', 'cuiusque', 'utroque', 'utriusque', 'uterque', 'ubique', 'quaecumque', 'utrimque', 'quemque', 'quodque', 'quique', 'plerisque', 'utrique', 'quocumque', 'quicumque', 'pleraque', 'quodcumque', 'quaque', 'quacumque', 'utramque', 'quamque', 'quandoque', 'ubicumque', 'plerosque', 'utcumque', 'quidque', 'quibusque', 'unusquisque', 'quosque', 'quasque', 'quotienscumque', 'cuiuscumque', 'quemcumque', 'inique', 'cuicumque', 'quousque',
-                               'tenue', 'siue', 'ioue', 'assidue', 'leue', 'adsidue', 'neue', 'niue', 'salue', 'quidue', 'breue', 'caue', 'graue', 'naue', 'pingue', 'praecipue'
-                               ]
-            # Kyle's exceptions
-            self.exceptions = ['atque', 'neque', 'quoque', 'itaque', 'usque', 'denique', 'quisque', 'namque', 'quinque', 'utique', 'plerumque', 'aeque', 'undique', 'cumque', 'plerique', 'utroque', 'uterque', 'ubique', 'utrimque', 'quocumque', 'quicumque', 'quaque', 'quacumque', 'que', 'quandoque', 'ubicumque', 'deque', 'utcumque', 'unusquisque', 'quotienscumque', 'inique', 'quousque', 'usquequaque', 'qualiscumque', 'utrasque', 'quantumcumque', 'oblique', 'absque', 'quandocumque', 'utrubique', 'quotiensque', 'antique', 'simulatque', 'quicque', 'undecumque', 'peraeque', 'utrobique', 'adusque', 'hucusque', 'adaeque', 'quomodocumque', 'quotcumque', 'quantuscumque', 'abusque', 'donique', 'inseque', 'circumundique', 'propinque', 'praecoque', 'quantuluscumque', 'longinque', 'conseque', 'utercumque', 'quotusquisque', 'quescumque', 'ne', 'sine', 'bene', 'sane', 'paene', 'plane', 'nonne', 'mane', 'commune', 'pone', 'impune', 'insigne', 'benigne', 'necne', 'pane', 'magne', 'anne', 'superne', 'opportune', 'digne', 'lene', 'immane', 'indigne', 'bone', 'maligne', 'plene', 'tisiphone', 'dione', 'urbane', 'sicine', 'procne', 'pene', 'erigone', 'alcyone', 'cyrene', 'germane', 'humane', 'hicine', 'segne', 'insane', 'syene', 'clymene', 'perenne', 'chione', 'condigne', 'cyllene', 'peropportune', 'messene', 'christiane', 'antigone', 'progne', 'amymone', 'persephone', 'pallene', 'oenone', 'fraterne', 'melpomene', 'inhumane', 'euadne', 'taprobane', 'helxine', 'hermione', 'pyrene', 'phryne', 'dine', 'serene', 'hicne', 'hucine', 'daphne', 'sabine', 'asine', 'cyane', 'commagene', 'concinne', 'obscene', 'chamaedaphne', 'theophane', 'nerine', 'diutine', 'perbene', 'inurbane', 'thyone', 'ismene', 'elephantine', 'amoene', 'anemone', 'stephane', 'torone', 'priene', 'arne', 'inferne', 'hippocrene', 'sophene', 'roxane', 'rhene', 'feminine', 'pirene', 'carcine', 'mnemosyne', 'nyctimene', 'susiane', 'pleione', 'pitane', 'mitylene', 'elatine', 'alsine', 'mytilene', 'matutine', 'oxymyrsine', 'peremne', 'hesione', 'absone', 'sithone', 'limone', 'acharne', 'hierabotane', 'euphrone', 'moene', 'zone', 'arachne', 'pellene', 'calymne', 'bizone', 'elleborine', 'impoene', 'corone', 'halcyone', 'paraetacene', 'istucine', 'chalbane', 'semiplene', 'masculine', 'acrisione', 'mesene', 'belone', 'praefiscine', 'consone', 'barine', 'inconcinne', 'aeschynomene', 'anadyomene', 'orphne', 'andrachne', 'pylene', 'prone', 'adhucine', 'hispane', 'aparine', 'importune', 'asiane', 'catacecaumene', 'chamaemyrsine', 'hedone', 'supine', 'myrmidone', 'nuncine', 'perindigne', 'prasiane', 'rhododaphne', 'euphrosyne', 'perbenigne', 'itone', 'patalene', 'bulbine', 'iasione', 'selene', 'praecipue', 'assidue', 'strenue', 'ambigue', 'sue', 'perspicue', 'congrue', 'incongrue', 'ingenue', 'exigue', 'fatue', 'continue', 'superflue', 'prospicue', 'mutue', 'fue', 'innocue', 'perexigue', 'supplicue', 'contigue']
-            # quisque, added manually by Kyle
-            self.exceptions = self.exceptions + ['quisque', 'quidque', 'quique', 'quaeque', 'quaeque', 'cuiusque', 'cuiusque', '', 'quorumque', 'quarumque', 'quorumque', 'cuique', 'cuique', 'quibusque', 'quibusque', 'quibusque', 'quemque', 'quidque', 'quosque', 'quasque', 'quaeque', 'quoque', 'quoque', 'quibusque', 'quibusque', 'quibusque']
-            self.exceptions = set(self.exceptions)
+          self.enclitics = ['que', 'ne', 'ue', 've', 'cum']
 
+          self.exceptions = self.enclitics
+
+          que_exceptions, ne_exceptions, ue_exceptions, ve_exceptions, cum_exceptions = [], [], [], [], []
+
+          # quisque
+          que_exceptions = que_exceptions + ['quisque', 'quidque', 'quicque', 'quodque', 'cuiusque', 'cuique', 'quemque', 'quoque', 'quique', 'quaeque', 'quorumque', 'quarumque', 'quibusque', 'quosque', 'quasque']
+
+          #uterque
+          que_exceptions = que_exceptions + ['uterque', 'utraque', 'utrumque', 'utriusque', 'utrique', 'utrumque', 'utramque', 'utroque', 'utraque', 'utrique', 'utraeque', 'utrorumque', 'utrarumque', 'utrisque', 'utrosque', 'utrasque']
+
+          #quiscumque
+          que_exceptions = que_exceptions + ['quicumque', 'quidcumque', 'quodcumque', 'cuiuscumque', 'cuicumque', 'quemcumque', 'quamcumque', 'quocumque', 'quacumque', 'quicumque', 'quaecumque', 'quorumcumque', 'quarumcumque', 'quibuscumque', 'quoscumque', 'quascumque']
+
+          #unuscumque
+          que_exceptions = que_exceptions + ['unusquisque', 'unaquaeque', 'unumquodque', 'unumquidque', 'uniuscuiusque', 'unicuique', 'unumquemque', 'unamquamque', 'unoquoque', 'unaquaque']
+
+          #plerusque
+          que_exceptions = que_exceptions + ['plerusque', 'pleraque', 'plerumque', 'plerique', 'pleraeque', 'pleroque', 'pleramque', 'plerorumque', 'plerarumque', 'plerisque', 'plerosque', 'plerasque']
+
+          #misc
+          que_exceptions = que_exceptions + ['absque', 'abusque', 'adaeque', 'adusque', 'aeque', 'antique', 'atque', 'circumundique', 'conseque', 'cumque', 'cunque', 'denique', 'deque', 'donique', 'hucusque', 'inique', 'inseque', 'itaque', 'longinque', 'namque', 'neque', 'oblique', 'peraeque', 'praecoque', 'propinque', 'qualiscumque', 'quandocumque', 'quandoque', 'quantuluscumque', 'quantumcumque', 'quantuscumque', 'quinque', 'quocumque', 'quomodocumque', 'quomque', 'quotacumque', 'quotcumque', 'quotienscumque', 'quotiensque', 'quotusquisque', 'quousque', 'relinque', 'simulatque', 'torque', 'ubicumque', 'ubique', 'undecumque', 'undique', 'usque', 'usquequaque', 'utcumque', 'utercumque', 'utique', 'utrimque', 'utrique', 'utriusque', 'utrobique', 'utrubique']
+
+          ne_exceptions = ne_exceptions + ['absone', 'acharne', 'acrisione', 'acumine', 'adhucine', 'adsuetudine', 'aeetine', 'aeschynomene', 'aesone', 'agamemnone', 'agmine', 'albane', 'alcyone', 'almone', 'alsine', 'amasene', 'ambitione', 'amne', 'amoene', 'amymone', 'anadyomene', 'andrachne', 'anemone', 'aniene', 'anne', 'antigone', 'aparine', 'apolline', 'aquilone', 'arachne', 'arne', 'arundine', 'ascanione', 'asiane', 'asine', 'aspargine', 'babylone', 'barine', 'bellone', 'belone', 'bene', 'benigne', 'bipenne', 'bizone', 'bone', 'bubone', 'bulbine', 'cacumine', 'caligine', 'calymne', 'cane', 'carcine', 'cardine', 'carmine', 'catacecaumene', 'catone', 'cerne', 'certamine', 'chalbane', 'chamaedaphne', 'chamaemyrsine', 'chaone', 'chione', 'christiane', 'clymene', 'cognomine', 'commagene', 'commune', 'compone', 'concinne', 'condicione', 'condigne', 'cone', 'confine', 'consone', 'corone', 'crastine', 'crepidine', 'crimine', 'crine', 'culmine', 'cupidine', 'cyane', 'cydne', 'cyllene', 'cyrene', 'daphne', 'depone', 'desine', 'dicione', 'digne', 'dine', 'dione', 'discrimine', 'diutine', 'dracone', 'dulcedine', 'elatine', 'elephantine', 'elleborine', 'epidamne', 'erigone', 'euadne', 'euphrone', 'euphrosyne', 'examine', 'faune', 'femine', 'feminine', 'ferrugine', 'fine', 'flamine', 'flumine', 'formidine', 'fragmine', 'fraterne', 'fulmine', 'fune', 'germane', 'germine', 'geryone', 'gorgone', 'gramine', 'grandine', 'haecine', 'halcyone', 'hammone', 'harundine', 'hedone', 'helene', 'helxine', 'hermione', 'heroine', 'hesione', 'hicine', 'hicne', 'hierabotane', 'hippocrene', 'hispane', 'hodierne', 'homine', 'hominesne', 'hortamine', 'hucine', 'humane', 'hunccine', 'huncine', 'iasione', 'iasone', 'igne', 'imagine', 'immane', 'immune', 'impoene', 'impone', 'importune', 'impune', 'inane', 'inconcinne', 'indagine', 'indigne', 'inferne', 'inguine', 'inhumane', 'inpone', 'inpune', 'insane', 'insigne', 'inurbane', 'ismene', 'istucine', 'itone', 'iuuene', 'karthagine', 'labiene', 'lacedaemone', 'lanugine', 'latine', 'legione', 'lene', 'lenone', 'libidine', 'limine', 'limone', 'lumine', 'magne', 'maligne', 'mane', 'margine', 'marone', 'masculine', 'matutine', 'medicamine', 'melpomene', 'memnone', 'mesene', 'messene', 'misene', 'mitylene', 'mnemosyne', 'moderamine', 'moene', 'mone', 'mortaline', 'mucrone', 'munimine', 'myrmidone', 'mytilene', 'necne', 'neptune', 'nequene', 'nerine', 'nocturne', 'nomine', 'nonne', 'nullane', 'numine', 'nuncine', 'nyctimene', 'obscene', 'obsidione', 'oenone', 'omine', 'omne', 'oppone', 'opportune', 'ordine', 'origine', 'orphne', 'oxymyrsine', 'paene', 'pallene', 'pane', 'paraetacene', 'patalene', 'pectine', 'pelagine', 'pellene', 'pene', 'perbene', 'perbenigne', 'peremne', 'perenne', 'perindigne', 'peropportune', 'persephone', 'phryne', 'pirene', 'pitane', 'plane', 'pleione', 'plene', 'pone', 'praefiscine', 'prasiane', 'priene', 'priuigne', 'procne', 'proditione', 'progne', 'prone', 'propone', 'pulmone', 'pylene', 'pyrene', 'pythone', 'ratione', 'regione', 'religione', 'remane', 'retine', 'rhene', 'rhododaphne', 'robigine', 'romane', 'roxane', 'rubigine', 'sabine', 'sane', 'sanguine', 'saturne', 'seditione', 'segne', 'selene', 'semine', 'semiplene', 'sene', 'sepone', 'serene', 'sermone', 'serrane', 'siccine', 'sicine', 'sine', 'sithone', 'solane', 'sollemne', 'somne', 'sophene', 'sperne', 'spiramine', 'stamine', 'statione', 'stephane', 'sterne', 'stramine', 'subpone', 'subtegmine', 'subtemine', 'sulmone', 'superne', 'supine', 'suppone', 'susiane', 'syene', 'tantane', 'tantine', 'taprobane', 'tegmine', 'telamone', 'temne', 'temone', 'tene', 'testudine', 'theophane', 'therone', 'thyone', 'tiberine', 'tibicine', 'tiburne', 'tirone', 'tisiphone', 'torone', 'transitione', 'troiane', 'turbine', 'turne', 'tyrrhene', 'uane', 'uelamine', 'uertigine', 'uesane', 'uimine', 'uirgine', 'umbone', 'unguine', 'uolumine', 'uoragine', 'urbane', 'uulcane', 'zone']
+
+          ue_exceptions = ue_exceptions + ['agaue', 'ambigue', 'assidue', 'aue', 'boue', 'breue', 'calue', 'caue', 'ciue', 'congrue', 'contigue', 'continue', 'curue', 'exigue', 'fatue', 'faue', 'fue', 'furtiue', 'gradiue', 'graue', 'ignaue', 'incongrue', 'ingenue', 'innocue', 'ioue', 'lasciue', 'leue', 'moue', 'mutue', 'naue', 'neue', 'niue', 'perexigue', 'perspicue', 'pingue', 'praecipue', 'praegraue', 'prospicue', 'proterue', 'remoue', 'resolue', 'saeue', 'salue', 'siue', 'solue', 'strenue', 'sue', 'summoue', 'superflue', 'supplicue', 'tenue', 'uiue', 'uoue']
+
+          ve_exceptions = ve_exceptions + ['agave', 'ave', 'bove', 'breve', 'calve', 'cave', 'cive', 'curve', 'fave', 'furtive', 'gradive', 'grave', 'ignave', 'iove', 'lascive', 'leve', 'move', 'nave', 'neve', 'nive', 'praegrave', 'prospicve', 'proterve', 'remove', 'resolve', 'saeve', 'salve', 'sive', 'solve', 'summove', 'vive', 'vove']
+
+          cum_exceptions = cum_exceptions + ['circum', 'locum', 'ducum', 'arcum', 'amicum', 'cilicum', 'quercum', 'caecum', 'siccum', 'oblicum', 'modicum', 'iuuencum', 'iocum', 'inimicum', 'uocum', 'truncum', 'silicum', 'raucum', 'pudicum', 'phoenicum', 'phaeacum', 'magnificum', 'lucum', 'cacum', 'amycum', 'actiacum', 'uiscum', 'uncum', 'thessalicum', 'tabificum', 'scythicum', 'salaminiacum', 'saetacum', 'quicum', 'propincum', 'priscum', 'opacum', 'nutricum', 'metiscum', 'meretricum', 'libycum', 'laticum', 'lacum', 'inicum', 'horrificum', 'glaucum', 'focum', 'fatidicum', 'cupencum', 'crocum', 'coruscum', 'cornicum', 'cappadocum', 'argolicum', 'anticum']
+
+          self.exceptions = set(self.exceptions + que_exceptions + ne_exceptions + ue_exceptions + ve_exceptions + cum_exceptions)
 
     def tokenize(self, string):
         """Tokenize incoming string."""
@@ -41,7 +66,7 @@ class WordTokenizer:  # pylint: disable=too-few-public-methods
             if generic_token not in self.exceptions:
                 for enclitic in self.enclitics:
                     if generic_token.endswith(enclitic):
-                        new_tokens = [generic_token[:-len(enclitic)]] + [enclitic]
+                        new_tokens = [generic_token[:-len(enclitic)]] + ['-' + enclitic]
                         specific_tokens += new_tokens
                         is_enclitic = True
                         break


### PR DESCRIPTION
- Handles: -que, -ne, -ue/-ve, -cum
- Includes expanded and better organized list of exceptions
- Prepends '-' (hyphen) to separated enclitics to better mark them in returned list, e.g. 'arma virumque' > ['arma','virum','-que']