### PR TITLE
Fixed namespace error

### DIFF
--- a/cltk/prosody/greek/scanner.py
+++ b/cltk/prosody/greek/scanner.py
@@ -23,7 +23,7 @@ __license__ = 'MIT License'
 import unittest
 
 
-class ScansionGreek:
+class Scansion:
 
     """Scans Greek texts, but does not macronize the text."""
 


### PR DESCRIPTION
Changed ScansionGreek to Scansion, all ten prosody tests run OK.