### PR TITLE
Added phi index with authors and works

### DIFF
--- a/cltk/corpus/latin/phi/phi_authors_works.json
+++ b/cltk/corpus/latin/phi/phi_authors_works.json
@@ -1,0 +1,2642 @@
+{
+   "LAT0002":{
+      "author":"T. Annius Luscus",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0004":{
+      "author":"App. Claudius Caecus",
+      "works":[
+         "sententiae"
+      ]
+   },
+   "LAT0007":{
+      "author":"Atilius",
+      "works":[
+         "palliatae"
+      ]
+   },
+   "LAT0010":{
+      "author":"M. Iunius Brutus [iur.]",
+      "works":[
+         "iurisprudentia"
+      ]
+   },
+   "LAT0013":{
+      "author":"Caecilius Statius",
+      "works":[
+         "palliatae"
+      ]
+   },
+   "LAT0016":{
+      "author":"L. Calpurnius Piso Censorinus Frugi",
+      "works":[
+         "Annales"
+      ]
+   },
+   "LAT0019":{
+      "author":"C. Papirius Carbo",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0022":{
+      "author":"M. Porcius Cato",
+      "works":[
+         "De Agri Cultura",
+         "De Agri Cultura, fragmenta",
+         "Dicta Memorabilia",
+         "epistulae",
+         "De Medicina",
+         "incertorum librorum fragmenta",
+         "iurisprudentia",
+         "De Re Militari",
+         "Carmen De Moribus",
+         "orationes",
+         "Origines",
+         "De Rhetorica"
+      ]
+   },
+   "LAT0025":{
+      "author":"M. Porcius M. f. M. n. Cato",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0027":{
+      "author":"L. Cincius Alimentus",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT0028":{
+      "author":"L. Coelius Antipater",
+      "works":[
+         "Annales"
+      ]
+   },
+   "LAT0031":{
+      "author":"Cornelia, mater Gracchorum",
+      "works":[
+         "epistula, fragmenta"
+      ]
+   },
+   "LAT0034":{
+      "author":"C. Scribonius Curio avus",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0037":{
+      "author":"C. Scribonius Curio pater",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0043":{
+      "author":"Q. Ennius",
+      "works":[
+         "Annales",
+         "palliatae",
+         "praetextae",
+         "Saturae",
+         "tragoediae",
+         "varia",
+         "incerta"
+      ]
+   },
+   "LAT0046":{
+      "author":"Cornelius Epicadus",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT0058":{
+      "author":"Q. Fabius Maximus Servilianus",
+      "works":[
+         "Annales"
+      ]
+   },
+   "LAT0061":{
+      "author":"Fabius Pictor",
+      "works":[
+         "Annales",
+         "Iuris Pontificis Libri"
+      ]
+   },
+   "LAT0064":{
+      "author":"C. Fannius",
+      "works":[
+         "historiae",
+         "orationes"
+      ]
+   },
+   "LAT0067":{
+      "author":"Favorinus",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0070":{
+      "author":"Cn. Gellius",
+      "works":[
+         "Annales"
+      ]
+   },
+   "LAT0073":{
+      "author":"C. Sempronius Gracchus",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0076":{
+      "author":"C. Cassius Hemina",
+      "works":[
+         "Annales"
+      ]
+   },
+   "LAT0079":{
+      "author":"Hostius",
+      "works":[
+         "Bellum Histricum"
+      ]
+   },
+   "LAT0082":{
+      "author":"D. Iunius Silanus",
+      "works":[
+         "versio Latina Magonis"
+      ]
+   },
+   "LAT0085":{
+      "author":"C. Laelius Sapiens",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0088":{
+      "author":"M. Aemilius Lepidus Porcina",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0091":{
+      "author":"Licinius Imbrex",
+      "works":[
+         "palliatae"
+      ]
+   },
+   "LAT0094":{
+      "author":"L. Livius Andronicus",
+      "works":[
+         "Odyssia",
+         "tragoediae",
+         "palliatae"
+      ]
+   },
+   "LAT0097":{
+      "author":"C. Lucilius",
+      "works":[
+         "Saturae, fragmenta"
+      ]
+   },
+   "LAT0100":{
+      "author":"Luscius Lanuvinus",
+      "works":[
+         "palliatae"
+      ]
+   },
+   "LAT0103":{
+      "author":"Cn. Marcius vates",
+      "works":[
+         "praecepta"
+      ]
+   },
+   "LAT0104":{
+      "author":"C. Memmius",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0106":{
+      "author":"Caecilius Metellus",
+      "works":[
+         "versus in Naevium"
+      ]
+   },
+   "LAT0109":{
+      "author":"Q. Caecilius Metellus Macedonicus",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0112":{
+      "author":"Cn. Naevius",
+      "works":[
+         "Bellum Punicum",
+         "alia carmina epica",
+         "palliatae",
+         "praetextae",
+         "tragoediae",
+         "carmina, frr. a Morel omissa",
+         "versus in Metellos [sp.]"
+      ]
+   },
+   "LAT0116":{
+      "author":"M. Pacuvius",
+      "works":[
+         "praetextae",
+         "tragoediae"
+      ]
+   },
+   "LAT0117":{
+      "author":"Papinius",
+      "works":[
+         "epigrammation"
+      ]
+   },
+   "LAT0118":{
+      "author":"L. Aemilius L. f. M. n. Paulus",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0119":{
+      "author":"T. Maccius Plautus",
+      "works":[
+         "Amphitruo",
+         "Asinaria",
+         "Aulularia",
+         "Bacchides",
+         "Captivi",
+         "Casina",
+         "Cistellaria",
+         "Curculio",
+         "Epidicus",
+         "Menaechmi",
+         "Mercator",
+         "Miles Gloriosus",
+         "Mostellaria",
+         "Persa",
+         "Poenulus",
+         "Pseudolus",
+         "Rudens",
+         "Stichus",
+         "Trinummus",
+         "Truculentus",
+         "Vidularia",
+         "Fragmenta"
+      ]
+   },
+   "LAT0122":{
+      "author":"A. Postumius Albinus",
+      "works":[
+         "Annales"
+      ]
+   },
+   "LAT0125":{
+      "author":"P. Mucius Scaevola",
+      "works":[
+         "fragmentum"
+      ]
+   },
+   "LAT0127":{
+      "author":"P. Cornelius Scipio Africanus maior",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0128":{
+      "author":"P. Cornelius Scipio Aemilianus Africanus minor",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0130":{
+      "author":"P. Cornelius Scipio Nasica Serapio",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0134":{
+      "author":"P. Terentius Afer",
+      "works":[
+         "Andria",
+         "Heauton Timorumenos",
+         "Eunuchus",
+         "Phormio",
+         "Hecyra",
+         "Adelphoe"
+      ]
+   },
+   "LAT0137":{
+      "author":"Titinius",
+      "works":[
+         "togatae"
+      ]
+   },
+   "LAT0140":{
+      "author":"C. Titius",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0143":{
+      "author":"Trabea",
+      "works":[
+         "palliatae"
+      ]
+   },
+   "LAT0146":{
+      "author":"Sex. Turpilius",
+      "works":[
+         "palliatae"
+      ]
+   },
+   "LAT0149":{
+      "author":"Carmen Arvale",
+      "works":[
+         "Carmen Arvale"
+      ]
+   },
+   "LAT0300":{
+      "author":"Sempronius Asellio",
+      "works":[
+         "Rerum Gestarum Libri"
+      ]
+   },
+   "LAT0301":{
+      "author":"Cn. Domitius Ahenobarbus",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0302":{
+      "author":"M. Antonius",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0303":{
+      "author":"Aurelius Opillus",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT0306":{
+      "author":"Carmen Devotionis",
+      "works":[
+         "Carmen Devotionis"
+      ]
+   },
+   "LAT0309":{
+      "author":"Carmen Evocationis",
+      "works":[
+         "Carmen Evocationis"
+      ]
+   },
+   "LAT0312":{
+      "author":"Fabius Dossennus",
+      "works":[
+         "carmina, fragmentum"
+      ]
+   },
+   "LAT0315":{
+      "author":"M. Iunius Gracchanus",
+      "works":[
+         "commentarii"
+      ]
+   },
+   "LAT0321":{
+      "author":"Porcius Licinus",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0324":{
+      "author":"Saserna",
+      "works":[
+         "De Agri Cultura"
+      ]
+   },
+   "LAT0327":{
+      "author":"L. Aelius Praeconinus Stilo",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT0330":{
+      "author":"Volcacius Sedigitus",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0400":{
+      "author":"L. Accius",
+      "works":[
+         "carmina",
+         "praetextae",
+         "tragoediae"
+      ]
+   },
+   "LAT0401":{
+      "author":"Aufustius",
+      "works":[
+         "grammatica, fragmenta"
+      ]
+   },
+   "LAT0402":{
+      "author":"Valerius Aedituus",
+      "works":[
+         "epigrammata"
+      ]
+   },
+   "LAT0404":{
+      "author":"L. Afranius",
+      "works":[
+         "togatae"
+      ]
+   },
+   "LAT0405":{
+      "author":"Clodius Tuscus",
+      "works":[
+         "grammatica, fragmenta"
+      ]
+   },
+   "LAT0406":{
+      "author":"P. Alfenus Varus",
+      "works":[
+         "iurisprudentia, fragmenta"
+      ]
+   },
+   "LAT0408":{
+      "author":"M. Antonius triumvir r. p. c.",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0409":{
+      "author":"Q. Cornificius",
+      "works":[
+         "carmina, fragmenta"
+      ]
+   },
+   "LAT0410":{
+      "author":"Aprissius (?)",
+      "works":[
+         "frg."
+      ]
+   },
+   "LAT0412":{
+      "author":"C. Aquilius Gallus",
+      "works":[
+         "iurisprudentia, fragmenta"
+      ]
+   },
+   "LAT0413":{
+      "author":"Gavius Bassus",
+      "works":[
+         "De Origine Vocabulorum, frr.",
+         "fragmentum"
+      ]
+   },
+   "LAT0414":{
+      "author":"L. Arruntius",
+      "works":[
+         "Historiae Belli Punici"
+      ]
+   },
+   "LAT0416":{
+      "author":"L. Ateius Praetextatus",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT0418":{
+      "author":"T. Quinctius Atta",
+      "works":[
+         "epigramma",
+         "togatae"
+      ]
+   },
+   "LAT0419":{
+      "author":"L. Orbilius Pupillus",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT0420":{
+      "author":"P. Aufidius Namusa",
+      "works":[
+         "iurisprudentia"
+      ]
+   },
+   "LAT0423":{
+      "author":"L. Herennius Balbus",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0425":{
+      "author":"P. Rutilius Lupus",
+      "works":[
+         "Schemata Lexeos"
+      ]
+   },
+   "LAT0426":{
+      "author":"Bellum Africum",
+      "works":[
+         "Bellum Africum"
+      ]
+   },
+   "LAT0428":{
+      "author":"Bellum Alexandrinum",
+      "works":[
+         "Bellum Alexandrinum"
+      ]
+   },
+   "LAT0430":{
+      "author":"Bellum Hispaniense",
+      "works":[
+         "Bellum Hispaniense"
+      ]
+   },
+   "LAT0432":{
+      "author":"M. Furius Bibaculus",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0436":{
+      "author":"M. Iunius Brutus [tyr.]",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0442":{
+      "author":"A. Caecina",
+      "works":[
+         "fragmentum"
+      ]
+   },
+   "LAT0444":{
+      "author":"M. Caelius Rufus",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0445":{
+      "author":"C. et L. Caepasii fratres",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0446":{
+      "author":"Q. Servilius Caepio",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0448":{
+      "author":"C. Iulius Caesar",
+      "works":[
+         "De Bello Gallico",
+         "Bellum Civile",
+         "orationes",
+         "De Analogia",
+         "Anticato",
+         "carmina",
+         "epistulae ad Ciceronem",
+         "epistulae ad familiares"
+      ]
+   },
+   "LAT0450":{
+      "author":"L. Iulius Caesar",
+      "works":[
+         "Auspiciorum Liber, fragmenta"
+      ]
+   },
+   "LAT0451":{
+      "author":"Sinnius Capito",
+      "works":[
+         "grammatica, fragmenta"
+      ]
+   },
+   "LAT0452":{
+      "author":"C. Iulius Caesar Strabo",
+      "works":[
+         "orationes",
+         "tragoediae"
+      ]
+   },
+   "LAT0454":{
+      "author":"M. Calidius",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0455":{
+      "author":"C. Calpurnius Piso",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0456":{
+      "author":"C. Licinius Macer Calvus",
+      "works":[
+         "carmina",
+         "orationes"
+      ]
+   },
+   "LAT0458":{
+      "author":"P. Cannutius",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0460":{
+      "author":"C. Papirius Carbo Arvina",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0466":{
+      "author":"A. Cascellius",
+      "works":[
+         "Liber Bene Dictorum, frr. duo"
+      ]
+   },
+   "LAT0469":{
+      "author":"L. Cassius Longinus",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0470":{
+      "author":"M. Porcius Cato Uticensis",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0472":{
+      "author":"C. Valerius Catullus",
+      "works":[
+         "carmina",
+         "carminum fragmenta"
+      ]
+   },
+   "LAT0473":{
+      "author":"Q. Lutatius Catulus iunior",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0474":{
+      "author":"M. Tullius Cicero",
+      "works":[
+         "Pro Quinctio",
+         "Pro S. Roscio Amerino",
+         "Pro Q. Roscio Comoedo",
+         "In Q. Caecilium",
+         "In Verrem",
+         "Pro Tullio",
+         "Pro Fonteio",
+         "Pro Caecina",
+         "Pro Lege Manilia",
+         "Pro Cluentio",
+         "De Lege Agraria",
+         "Pro Rabirio Perduellionis Reo",
+         "In Catilinam",
+         "Pro Murena",
+         "Pro Sulla",
+         "Pro Archia",
+         "Pro Flacco",
+         "Post Reditum ad Populum",
+         "Post Reditum in Senatu",
+         "De Domo Sua",
+         "De Haruspicum Responso",
+         "Pro Sestio",
+         "In Vatinium",
+         "Pro Caelio",
+         "De Provinciis Consularibus",
+         "Pro Balbo",
+         "In Pisonem",
+         "Pro Plancio",
+         "Pro Scauro",
+         "Pro Rabirio Postumo",
+         "Pro Milone",
+         "Pro Marcello",
+         "Pro Ligario",
+         "Pro Rege Deiotaro",
+         "Philippicae",
+         "De Inventione",
+         "De Oratore",
+         "De Partitione Oratoria",
+         "Brutus",
+         "Orator",
+         "De Optimo Genere Oratorum",
+         "Topica",
+         "De Republica",
+         "De Legibus",
+         "Academica",
+         "Lucullus",
+         "Paradoxa Stoicorum",
+         "De Finibus",
+         "Tusculanae Disputationes",
+         "De Natura Deorum",
+         "Cato Maior de Senectute",
+         "Laelius de Amicitia",
+         "De Divinatione",
+         "De Fato",
+         "De Officiis",
+         "Epistulae ad Familiares",
+         "Epistulae ad Atticum",
+         "Epistulae ad Quintum Fratrem",
+         "Epistulae ad Brutum",
+         "Arati Phaenomena",
+         "Facete Dicta",
+         "carmina, fragmenta",
+         "Commentarii Causarum",
+         "epistulae, fragmenta",
+         "Hortensius",
+         "incertorum librorum fragmenta",
+         "De Iure Civ. in Artem Redig.",
+         "orationum deperditarum frr.",
+         "orationum incertarum frr.",
+         "philosophicorum librorum frr.",
+         "Arati Prognostica",
+         "Timaeus",
+         "Rhetorica ad Herennium [sp.]",
+         "In Sallustium [sp.]",
+         "epistula ad Octavianum [sp.]"
+      ]
+   },
+   "LAT0478":{
+      "author":"Q. Tullius Cicero",
+      "works":[
+         "carmina",
+         "Commentar. Petitionis [sp.]"
+      ]
+   },
+   "LAT0484":{
+      "author":"L. Cincius",
+      "works":[
+         "grammatica",
+         "iurisprudentia"
+      ]
+   },
+   "LAT0486":{
+      "author":"C. Helvius Cinna",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0487":{
+      "author":"P. Clodius Pulcher",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0488":{
+      "author":"Ser. Clodius",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT0490":{
+      "author":"P. Cominius",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0492":{
+      "author":"Commentarii Augurum",
+      "works":[
+         "Commentarii Augurum"
+      ]
+   },
+   "LAT0494":{
+      "author":"Commentarii Consulares",
+      "works":[
+         "Commentarii Consulares"
+      ]
+   },
+   "LAT0496":{
+      "author":"Commentarius Anquisitionis M'. Sergii M'. f. Quaestoris",
+      "works":[
+         "Comment. Anquisit. Sergii"
+      ]
+   },
+   "LAT0498":{
+      "author":"C. Aurelius Cotta",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0500":{
+      "author":"L. Licinius Crassus",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0502":{
+      "author":"A. Cremutius Cordus",
+      "works":[
+         "Annales"
+      ]
+   },
+   "LAT0510":{
+      "author":"P. Cornelius Dolabella",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0512":{
+      "author":"M. Duronius",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0514":{
+      "author":"Egnatius",
+      "works":[
+         "De Rerum Natura"
+      ]
+   },
+   "LAT0515":{
+      "author":"Sex. (vel Sp.) Ennius",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT0516":{
+      "author":"C. Erucius",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0518":{
+      "author":"A. Furius Antias",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0522":{
+      "author":"C. Aelius Gallus",
+      "works":[
+         "De Verbis ad Ius Civile",
+         "iurisprudentia, fragmenta"
+      ]
+   },
+   "LAT0524":{
+      "author":"C. Cornelius Gallus",
+      "works":[
+         "elegia",
+         "elegia in pap. Qas%1r Ibri=m"
+      ]
+   },
+   "LAT0526":{
+      "author":"C. Servilius Glaucia",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0527":{
+      "author":"Gannius",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0528":{
+      "author":"Granius Flaccus",
+      "works":[
+         "iurisprudentia"
+      ]
+   },
+   "LAT0530":{
+      "author":"A. Hirtius",
+      "works":[
+         "De Bello Gallico Liber VIII",
+         "epistulae"
+      ]
+   },
+   "LAT0532":{
+      "author":"Q. Hortensius Hortalus",
+      "works":[
+         "carmina",
+         "orationes"
+      ]
+   },
+   "LAT0533":{
+      "author":"C. Iulius Hyginus",
+      "works":[
+         "grammatica",
+         "historiae"
+      ]
+   },
+   "LAT0534":{
+      "author":"Iuventius",
+      "works":[
+         "palliatae"
+      ]
+   },
+   "LAT0535":{
+      "author":"M. Iuventius Laterensis",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0536":{
+      "author":"D. Laberius",
+      "works":[
+         "mimi"
+      ]
+   },
+   "LAT0537":{
+      "author":"T. Labienus",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0538":{
+      "author":"Laevius",
+      "works":[
+         "carmina",
+         "fr. dubium a Morel omissum"
+      ]
+   },
+   "LAT0540":{
+      "author":"Tullius Laurea",
+      "works":[
+         "epigramma in Ciceronis obitum"
+      ]
+   },
+   "LAT0541":{
+      "author":"Cn. Cornelius Lentulus Marcellinus",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0546":{
+      "author":"C. Licinius Mucianus",
+      "works":[
+         "historiae"
+      ]
+   },
+   "LAT0550":{
+      "author":"T. Lucretius Carus",
+      "works":[
+         "De Rerum Natura",
+         "fragmenta",
+         "Capitula"
+      ]
+   },
+   "LAT0552":{
+      "author":"Q. Lutatius Catulus",
+      "works":[
+         "epigrammata",
+         "Communes Historiae"
+      ]
+   },
+   "LAT0556":{
+      "author":"C. Licinius Macer",
+      "works":[
+         "Annales",
+         "oratio"
+      ]
+   },
+   "LAT0558":{
+      "author":"C. Maecenas",
+      "works":[
+         "carmina",
+         "fragmentum a Morel omissum"
+      ]
+   },
+   "LAT0560":{
+      "author":"Helvius Mancia",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0562":{
+      "author":"Manilius",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0564":{
+      "author":"M'.  Manilius",
+      "works":[
+         "iurisprudentia"
+      ]
+   },
+   "LAT0568":{
+      "author":"Cn. Matius",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0574":{
+      "author":"C. Memmius L. f.",
+      "works":[
+         "carmina",
+         "orationes"
+      ]
+   },
+   "LAT0576":{
+      "author":"M. Valerius Messalla Rufus",
+      "works":[
+         "De Familiis Romanis",
+         "De Auspiciis"
+      ]
+   },
+   "LAT0582":{
+      "author":"Q. Caecilius Metellus Numidicus",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0584":{
+      "author":"Mimi Poetarum Incertorum",
+      "works":[
+         "Mimi Poetarum Incertorum",
+         "fragmenta dubia"
+      ]
+   },
+   "LAT0586":{
+      "author":"Mummius",
+      "works":[
+         "Atellanae"
+      ]
+   },
+   "LAT0587":{
+      "author":"Naevius",
+      "works":[
+         "Ilias"
+      ]
+   },
+   "LAT0588":{
+      "author":"Cornelius Nepos",
+      "works":[
+         "Vitae",
+         "fragmenta"
+      ]
+   },
+   "LAT0590":{
+      "author":"P. Nigidius Figulus",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT0591":{
+      "author":"Ninnius Crassus",
+      "works":[
+         "Ilias"
+      ]
+   },
+   "LAT0592":{
+      "author":"Novius",
+      "works":[
+         "Atellanae"
+      ]
+   },
+   "LAT0594":{
+      "author":"L. Novius",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0596":{
+      "author":"Numitorius",
+      "works":[
+         "Antibucolica"
+      ]
+   },
+   "LAT0600":{
+      "author":"C. Oppius",
+      "works":[
+         "De Silvestribus Arboribus",
+         "vitae"
+      ]
+   },
+   "LAT0606":{
+      "author":"L. Marcius Philippus",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0614":{
+      "author":"Q. Pompeius Q. f. A. n. Rufus",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0615":{
+      "author":"Q. Pompeius Q. f. Q. n. Rufus",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0616":{
+      "author":"Pompilius",
+      "works":[
+         "epigramma",
+         "tragoedia"
+      ]
+   },
+   "LAT0618":{
+      "author":"L. Pomponius Bononiensis",
+      "works":[
+         "Atellanae"
+      ]
+   },
+   "LAT0620":{
+      "author":"Sex. Propertius",
+      "works":[
+         "Elegiae"
+      ]
+   },
+   "LAT0622":{
+      "author":"Publilius Syrus",
+      "works":[
+         "Sententiae",
+         "mimi"
+      ]
+   },
+   "LAT0624":{
+      "author":"Q. Claudius Quadrigarius",
+      "works":[
+         "Annales"
+      ]
+   },
+   "LAT0625":{
+      "author":"L. Quinctius",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT0628":{
+      "author":"P. Rutilius Rufus",
+      "works":[
+         "De Vita Sua"
+      ]
+   },
+   "LAT0630":{
+      "author":"Sacra Argeorum",
+      "works":[
+         "Sacra Argeorum"
+      ]
+   },
+   "LAT0631":{
+      "author":"C. Sallustius Crispus",
+      "works":[
+         "Catilinae Coniuratio",
+         "Bellum Iugurthinum",
+         "Historiae",
+         "Historiarum frr. ampliora",
+         "Historiarum frr. e codicibus",
+         "Historiarum frr. e papyris",
+         "Ad Caesarem de Re Publ. [sp.]",
+         "In M. Tullium Ciceronem [sp.]"
+      ]
+   },
+   "LAT0634":{
+      "author":"Santra",
+      "works":[
+         "tragoediae",
+         "grammatica"
+      ]
+   },
+   "LAT0635":{
+      "author":"P. Saturius",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0636":{
+      "author":"Q. Mucius Scaevola",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0638":{
+      "author":"Q. Mucius Scaevola [pontifex]",
+      "works":[
+         "iurisprudentia, fragmenta"
+      ]
+   },
+   "LAT0640":{
+      "author":"M. Aemilius Scaurus",
+      "works":[
+         "De Vita Sua",
+         "orationes"
+      ]
+   },
+   "LAT0642":{
+      "author":"Sevius Nicanor",
+      "works":[
+         "carmen"
+      ]
+   },
+   "LAT0644":{
+      "author":"Sextilius Ena",
+      "works":[
+         "carmen"
+      ]
+   },
+   "LAT0646":{
+      "author":"L. Cornelius Sisenna",
+      "works":[
+         "Historiae",
+         "Milesiae"
+      ]
+   },
+   "LAT0648":{
+      "author":"Staberius Eros",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT0650":{
+      "author":"Sueius",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0652":{
+      "author":"L. Cornelius Sulla",
+      "works":[
+         "Commentarii Rerum Gestarum"
+      ]
+   },
+   "LAT0656":{
+      "author":"Ser. Sulpicius Rufus",
+      "works":[
+         "iurisprudentia",
+         "oratio"
+      ]
+   },
+   "LAT0658":{
+      "author":"Tabulae Censoriae",
+      "works":[
+         "Tabulae Censoriae"
+      ]
+   },
+   "LAT0660":{
+      "author":"Albius Tibullus",
+      "works":[
+         "Elegiae",
+         "carmina Tibulliana [sp.]"
+      ]
+   },
+   "LAT0661":{
+      "author":"Ticidas",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0662":{
+      "author":"M. Tullius Tiro",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT0664":{
+      "author":"C. Trebatius Testa",
+      "works":[
+         "iurisprudentia et al."
+      ]
+   },
+   "LAT0668":{
+      "author":"Cn. Tremelius Scrofa",
+      "works":[
+         "de re rustica"
+      ]
+   },
+   "LAT0670":{
+      "author":"Q. Aelius Tubero",
+      "works":[
+         "Historiae",
+         "liber ad C. Oppium, fr."
+      ]
+   },
+   "LAT0672":{
+      "author":"Turranius Niger",
+      "works":[
+         "de re rustica scripta"
+      ]
+   },
+   "LAT0674":{
+      "author":"Valerius",
+      "works":[
+         "comoedia"
+      ]
+   },
+   "LAT0676":{
+      "author":"Valerius Antias",
+      "works":[
+         "Annales"
+      ]
+   },
+   "LAT0678":{
+      "author":"Q. Valerius Soranus",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0680":{
+      "author":"C. Valgius Rufus",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0682":{
+      "author":"L. Varius Rufus",
+      "works":[
+         "carmina",
+         "tragoediae"
+      ]
+   },
+   "LAT0684":{
+      "author":"M. Terentius Varro",
+      "works":[
+         "De Lingua Latina",
+         "Res Rusticae",
+         "Antiquitates Rerum Humanarum",
+         "Antiquitates Rerum Divinarum",
+         "Annales",
+         "De Gente Populi Romani",
+         "De Vita Populi Romani",
+         "Res Urbanae",
+         "Logistorici",
+         "carmina",
+         "Menippeae",
+         "epistulae",
+         "epistulae Latinae",
+         "fragmenta grammatica",
+         "frr. de historia litterarum",
+         "fragmenta varia",
+         "incertae sedis fragmenta"
+      ]
+   },
+   "LAT0686":{
+      "author":"P. Terentius Varro Atacinus",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0690":{
+      "author":"P. Vergilius Maro",
+      "works":[
+         "Eclogae",
+         "Georgica",
+         "Aeneis"
+      ]
+   },
+   "LAT0692":{
+      "author":"Appendix Vergiliana",
+      "works":[
+         "Dirae",
+         "Lydia",
+         "Culex",
+         "Aetna",
+         "Copa",
+         "Elegiae in Maecenatem",
+         "Ciris",
+         "Priapea",
+         "Catalepton",
+         "Priapeum 'Quid Hoc Novi Est?'",
+         "Moretum",
+         "De Institutione Viri Boni",
+         "De Est et Non",
+         "De Rosis Nascentibus"
+      ]
+   },
+   "LAT0694":{
+      "author":"Volumnius",
+      "works":[
+         "carmen"
+      ]
+   },
+   "LAT0703":{
+      "author":"Arbonius Silo",
+      "works":[
+         "carmen"
+      ]
+   },
+   "LAT0706":{
+      "author":"Carmen de Bello Aegyptiaco",
+      "works":[
+         "Carmen de Bello Aegyptiaco"
+      ]
+   },
+   "LAT0709":{
+      "author":"Domitius Marsus",
+      "works":[
+         "carmina",
+         "epigrammata ex Bobiensibus"
+      ]
+   },
+   "LAT0721":{
+      "author":"Antonius Panurgus",
+      "works":[
+         "grammatica, fragmentum"
+      ]
+   },
+   "LAT0724":{
+      "author":"Cloatius Verus",
+      "works":[
+         "grammatica fragmenta"
+      ]
+   },
+   "LAT0727":{
+      "author":"Cornificius Longus",
+      "works":[
+         "grammatica, fragmenta"
+      ]
+   },
+   "LAT0730":{
+      "author":"Tarquitius Priscus",
+      "works":[
+         "De Disciplina Etrusca, frr."
+      ]
+   },
+   "LAT0800":{
+      "author":"Albinovanus Pedo",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0803":{
+      "author":"Q. Asconius Pedianus",
+      "works":[
+         "In Senatu Contra L. Pisonem",
+         "Pro Scauro",
+         "Pro Milone",
+         "Pro Cornelio",
+         "In Toga Candida"
+      ]
+   },
+   "LAT0806":{
+      "author":"C. Ateius Capito",
+      "works":[
+         "iurisprudentia"
+      ]
+   },
+   "LAT0809":{
+      "author":"Aufidius Bassus",
+      "works":[
+         "historiae"
+      ]
+   },
+   "LAT0812":{
+      "author":"C. Caesius Bassus",
+      "works":[
+         "carmen",
+         "De Metris, fragmenta",
+         "De Metris Horatii [sp.]",
+         "Breviatio Pedum [sp.]",
+         "De Compositionibus [sp.]",
+         "Genera Versuum [sp.]",
+         "Poeticae Species Lat. [sp.]"
+      ]
+   },
+   "LAT0815":{
+      "author":"Bruttedius Niger",
+      "works":[
+         "historiae"
+      ]
+   },
+   "LAT0821":{
+      "author":"Bucolica Einsidlensia",
+      "works":[
+         "Bucolica Einsidlensia"
+      ]
+   },
+   "LAT0824":{
+      "author":"Cn. Arulenus Caelius Sabinus",
+      "works":[
+         "iurisprudentia, fragmenta"
+      ]
+   },
+   "LAT0827":{
+      "author":"Caesellius Vindex",
+      "works":[
+         "grammatica, fragmenta"
+      ]
+   },
+   "LAT0830":{
+      "author":"T. Calpurnius Siculus",
+      "works":[
+         "Eclogae"
+      ]
+   },
+   "LAT0836":{
+      "author":"A. Cornelius Celsus",
+      "works":[
+         "De Agricultura",
+         "De Medicina",
+         "De Rhetorica"
+      ]
+   },
+   "LAT0842":{
+      "author":"C. Clodius Licinus",
+      "works":[
+         "Libri Rerum Romanarum"
+      ]
+   },
+   "LAT0845":{
+      "author":"L. Iunius Moderatus Columella",
+      "works":[
+         "De Arboribus",
+         "De Re Rustica"
+      ]
+   },
+   "LAT0851":{
+      "author":"Cornelius Severus",
+      "works":[
+         "carmina",
+         "fragmenta a Morel omissa"
+      ]
+   },
+   "LAT0854":{
+      "author":"Cornificius Gallus",
+      "works":[
+         "versus in Vergilium"
+      ]
+   },
+   "LAT0857":{
+      "author":"L. Annaeus Cornutus",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT0860":{
+      "author":"Q. Curtius Rufus",
+      "works":[
+         "Historiae Alexandri Magni"
+      ]
+   },
+   "LAT0863":{
+      "author":"Dorcatius",
+      "works":[
+         "carmen"
+      ]
+   },
+   "LAT0866":{
+      "author":"Fenestella",
+      "works":[
+         "Annales"
+      ]
+   },
+   "LAT0869":{
+      "author":"M. Verrius Flaccus",
+      "works":[
+         "Etruscarum Rerum Libri",
+         "grammatica"
+      ]
+   },
+   "LAT0875":{
+      "author":"Cn. Cornelius Lentulus Gaetulicus",
+      "works":[
+         "carmen"
+      ]
+   },
+   "LAT0878":{
+      "author":"C. Asinius Gallus",
+      "works":[
+         "carmen",
+         "grammatica"
+      ]
+   },
+   "LAT0881":{
+      "author":"Claudius Caesar Germanicus",
+      "works":[
+         "Aratea",
+         "fragmenta Aratea",
+         "epigrammata"
+      ]
+   },
+   "LAT0884":{
+      "author":"Gracchus",
+      "works":[
+         "tragoediae"
+      ]
+   },
+   "LAT0887":{
+      "author":"Grattius",
+      "works":[
+         "Cynegetica"
+      ]
+   },
+   "LAT0890":{
+      "author":"Homerus Latinus",
+      "works":[
+         "Ilias Latina"
+      ]
+   },
+   "LAT0893":{
+      "author":"Q. Horatius Flaccus",
+      "works":[
+         "Carmina",
+         "Carmen Saeculare",
+         "Epodi",
+         "Sermones",
+         "Epistulae",
+         "Ars Poetica"
+      ]
+   },
+   "LAT0899":{
+      "author":"Hyginus Astronomus",
+      "works":[
+         "Astronomica"
+      ]
+   },
+   "LAT0902":{
+      "author":"Iulius Africanus",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0905":{
+      "author":"M. Antistius Labeo",
+      "works":[
+         "iurisprudentia, fragmenta"
+      ]
+   },
+   "LAT0908":{
+      "author":"Attius Labeo",
+      "works":[
+         "versio Latina Iliados"
+      ]
+   },
+   "LAT0911":{
+      "author":"Laus Pisonis",
+      "works":[
+         "Laus Pisonis"
+      ]
+   },
+   "LAT0914":{
+      "author":"T. Livius",
+      "works":[
+         "Ab Urbe Condita",
+         "Periochae Librorum A. U. C.",
+         "fragmenta",
+         "A.U.C. Perioch. ex P.Oxy.668"
+      ]
+   },
+   "LAT0917":{
+      "author":"M. Annaeus Lucanus",
+      "works":[
+         "Bellum Civile",
+         "carmina"
+      ]
+   },
+   "LAT0920":{
+      "author":"Lucilius iunior",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0923":{
+      "author":"Aemilius Macer",
+      "works":[
+         "carmina",
+         "fragmentum a Morel omissum"
+      ]
+   },
+   "LAT0926":{
+      "author":"M. Manilius",
+      "works":[
+         "Astronomica"
+      ]
+   },
+   "LAT0929":{
+      "author":"Pomponius Mela",
+      "works":[
+         "De Chorographia"
+      ]
+   },
+   "LAT0932":{
+      "author":"M. Valerius Messalla Corvinus",
+      "works":[
+         "orationes",
+         "Commentarii de Bello Civili"
+      ]
+   },
+   "LAT0935":{
+      "author":"Iulius Modestus",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT0938":{
+      "author":"Iulius Montanus",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0944":{
+      "author":"Imperator Nero",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT0959":{
+      "author":"P. Ovidius Naso",
+      "works":[
+         "Amores",
+         "Epistulae (vel Heroides)",
+         "Medicamina Faciei Femineae",
+         "Ars Amatoria",
+         "Remedia Amoris",
+         "Metamorphoses",
+         "Fasti",
+         "Tristia",
+         "Epistulae ex Ponto",
+         "Ibis",
+         "Medea",
+         "carmina, fragmenta",
+         "Nux [sp.]",
+         "Halieutica [sp.]",
+         "Epicedion Drusi [sp.]"
+      ]
+   },
+   "LAT0963":{
+      "author":"Q. Remmius Palaemon",
+      "works":[
+         "grammatica",
+         "Ars [sp.]"
+      ]
+   },
+   "LAT0966":{
+      "author":"Passienus Crispus",
+      "works":[
+         "oratio"
+      ]
+   },
+   "LAT0969":{
+      "author":"A. Persius Flaccus",
+      "works":[
+         "Saturae"
+      ]
+   },
+   "LAT0972":{
+      "author":"Petronius",
+      "works":[
+         "Satyrica",
+         "Satyrica, fragmenta"
+      ]
+   },
+   "LAT0975":{
+      "author":"Phaedrus",
+      "works":[
+         "Fabulae Aesopiae",
+         "Fabularum Appendix"
+      ]
+   },
+   "LAT0978":{
+      "author":"C. Plinius Secundus",
+      "works":[
+         "Naturalis Historia",
+         "Dubius Sermo"
+      ]
+   },
+   "LAT0981":{
+      "author":"C. Asinius Pollio",
+      "works":[
+         "carmina",
+         "orationes",
+         "grammatica",
+         "historiae"
+      ]
+   },
+   "LAT0984":{
+      "author":"Pompeius Trogus",
+      "works":[
+         "De Animalibus",
+         "Historiae Philippicae"
+      ]
+   },
+   "LAT0987":{
+      "author":"P. Pomponius Secundus",
+      "works":[
+         "tragoediae",
+         "praetextae"
+      ]
+   },
+   "LAT0990":{
+      "author":"Precatio Omnium Herbarum",
+      "works":[
+         "Precatio Omnium Herbarum"
+      ]
+   },
+   "LAT0993":{
+      "author":"Precatio Terrae",
+      "works":[
+         "Precatio Terrae"
+      ]
+   },
+   "LAT0996":{
+      "author":"M. Valerius Probus",
+      "works":[
+         "Vita Persii",
+         "De Notis Iuris",
+         "fragmenta"
+      ]
+   },
+   "LAT1000":{
+      "author":"Pupius (?)",
+      "works":[
+         "versus Pupio attributi"
+      ]
+   },
+   "LAT1002":{
+      "author":"M. Fabius Quintilianus",
+      "works":[
+         "Institutio Oratoria",
+         "Declamationes Minores",
+         "Declamationes Maiores [sp.]"
+      ]
+   },
+   "LAT1005":{
+      "author":"Rabirius",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT1011":{
+      "author":"Scribonius Largus",
+      "works":[
+         "Compositiones"
+      ]
+   },
+   "LAT1014":{
+      "author":"L. Annaeus Seneca senior",
+      "works":[
+         "Controversiae",
+         "Controversiae, excerpta",
+         "Suasoriae",
+         "Fragmenta"
+      ]
+   },
+   "LAT1017":{
+      "author":"L. Annaeus Seneca iunior",
+      "works":[
+         "Hercules Furens",
+         "Troades",
+         "Phoenissae",
+         "Medea",
+         "Phaedra",
+         "Oedipus",
+         "Agamemnon",
+         "Thyestes",
+         "Hercules Oetaeus",
+         "Octavia [sp.]",
+         "Apocolocyntosis",
+         "Dialogi",
+         "De Beneficiis",
+         "De Clementia",
+         "Epistulae Morales ad Lucilium",
+         "Naturales Quaestiones",
+         "e Cleanthe versus",
+         "De Vita Patris"
+      ]
+   },
+   "LAT1020":{
+      "author":"P. Papinius Statius",
+      "works":[
+         "Thebais",
+         "Silvae",
+         "Achilleis",
+         "De Bello Germanico (fragment)"
+      ]
+   },
+   "LAT1023":{
+      "author":"Sulpicia, Caleni uxor",
+      "works":[
+         "carmen",
+         "De Statu Rei Publicae [sp.]"
+      ]
+   },
+   "LAT1029":{
+      "author":"Turnus",
+      "works":[
+         "satura"
+      ]
+   },
+   "LAT1032":{
+      "author":"Vagellius",
+      "works":[
+         "carmen"
+      ]
+   },
+   "LAT1035":{
+      "author":"C. Valerius Flaccus",
+      "works":[
+         "Argonautica"
+      ]
+   },
+   "LAT1038":{
+      "author":"Valerius Maximus",
+      "works":[
+         "Facta et Dicta Memorabilia"
+      ]
+   },
+   "LAT1041":{
+      "author":"Pseudo-Varro",
+      "works":[
+         "Sententiae"
+      ]
+   },
+   "LAT1044":{
+      "author":"Velleius Paterculus",
+      "works":[
+         "Historia Romana"
+      ]
+   },
+   "LAT1047":{
+      "author":"Veranius",
+      "works":[
+         "libri de rebus sacris"
+      ]
+   },
+   "LAT1050":{
+      "author":"L. Verginius Rufus",
+      "works":[
+         "epigramma"
+      ]
+   },
+   "LAT1053":{
+      "author":"Q. Vibius Crispus",
+      "works":[
+         "orationes"
+      ]
+   },
+   "LAT1056":{
+      "author":"Vitruvius Pollio",
+      "works":[
+         "De Architectura"
+      ]
+   },
+   "LAT1100":{
+      "author":"Calpurnius Flaccus",
+      "works":[
+         "Declamationes, excerpta"
+      ]
+   },
+   "LAT1103":{
+      "author":"Priapea",
+      "works":[
+         "Priapea"
+      ]
+   },
+   "LAT1203":{
+      "author":"Alfius Avitus",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT1206":{
+      "author":"L. Ampelius",
+      "works":[
+         "Liber Memorialis"
+      ]
+   },
+   "LAT1209":{
+      "author":"Annianus",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT1212":{
+      "author":"Apuleius Madaurensis",
+      "works":[
+         "Apologia",
+         "Metamorphoses",
+         "Florida",
+         "De Deo Socratis",
+         "Anechomenos",
+         "carmina",
+         "fragmenta",
+         "De Mundo",
+         "De Platone et Eius Dogmate",
+         "De Deo Socratis, Praef. [sp.]"
+      ]
+   },
+   "LAT1218":{
+      "author":"Sentius Augurinus",
+      "works":[
+         "carmen"
+      ]
+   },
+   "LAT1221":{
+      "author":"C. Iulius Caesar Augustus Octavianus",
+      "works":[
+         "carmina",
+         "dicta et apophthegmata",
+         "edicta",
+         "epistulae",
+         "fragmenta incertae sedis",
+         "opera historica",
+         "Res Gestae",
+         "oratio"
+      ]
+   },
+   "LAT1224":{
+      "author":"M. Aurelius",
+      "works":[
+         "carmen"
+      ]
+   },
+   "LAT1227":{
+      "author":"Balbus",
+      "works":[
+         "Expos. et Ratio Omn. Formarum"
+      ]
+   },
+   "LAT1229":{
+      "author":"Flavius Caper",
+      "works":[
+         "De Orthographia",
+         "De Verbis Dubiis"
+      ]
+   },
+   "LAT1234":{
+      "author":"Didascaliae et Argumenta in Plautum",
+      "works":[
+         "Amphitruo",
+         "Asinaria",
+         "Aulularia",
+         "Captivi",
+         "Casina",
+         "Cistellaria",
+         "Curculio",
+         "Epidicus",
+         "Menaechmi",
+         "Mercator",
+         "Miles Gloriosus",
+         "Mostellaria",
+         "Persa",
+         "Poenulus",
+         "Pseudolus",
+         "Rudens",
+         "Stichus",
+         "Trinummus",
+         "Truculentus"
+      ]
+   },
+   "LAT1235":{
+      "author":"Didascaliae et Periochae in Terentium",
+      "works":[
+         "Andria",
+         "Heauton Timorumenos",
+         "Eunuchus",
+         "Phormio",
+         "Hecyra",
+         "Adelphoe"
+      ]
+   },
+   "LAT1236":{
+      "author":"Sex. Pompeius Festus",
+      "works":[
+         "De Verborum Significatione"
+      ]
+   },
+   "LAT1242":{
+      "author":"Annius Florus",
+      "works":[
+         "Epitome Bell. Omn. Ann. DCC",
+         "Vergilius Orator an Poeta",
+         "carmina in Anthologia Latina",
+         "carmina",
+         "epist. ad imperat. Hadrianum"
+      ]
+   },
+   "LAT1245":{
+      "author":"Sex. Iulius Frontinus",
+      "works":[
+         "Strategemata",
+         "De Aquis Urbis Romae",
+         "De Agrorum Qualitate",
+         "De Controversiis",
+         "De Limitibus",
+         "De Arte Mensoria"
+      ]
+   },
+   "LAT1248":{
+      "author":"M. Cornelius Fronto",
+      "works":[
+         "Ad M. Caesarem et Invicem",
+         "Ad M. Antoninum Imp. Epist.",
+         "Ad Verum Imp. Epistulae",
+         "De Eloquentia",
+         "De Orationibus",
+         "Ad Antoninum Pium Epistulae",
+         "Ad Amicos Epistulae",
+         "Principia Historiae",
+         "Laudes Fumi et Pulveris",
+         "Laudes Neglegentiae",
+         "De Bello Parthico",
+         "De Feriis Alsiensibus",
+         "De Nepote Amisso",
+         "Arion",
+         "Additamentum Epist. Aceph.",
+         "fragmenta",
+         "carmina"
+      ]
+   },
+   "LAT1251":{
+      "author":"Gaius",
+      "works":[
+         "Institutiones",
+         "Institut., frr. Aeg. et Oxyrh.",
+         "Gai Institutionum epitome"
+      ]
+   },
+   "LAT1254":{
+      "author":"A. Gellius",
+      "works":[
+         "Noctes Atticae"
+      ]
+   },
+   "LAT1257":{
+      "author":"Granius Licinianus",
+      "works":[
+         "Annales"
+      ]
+   },
+   "LAT1260":{
+      "author":"Hadrianus",
+      "works":[
+         "carmina",
+         "orationes"
+      ]
+   },
+   "LAT1263":{
+      "author":"Hyginus",
+      "works":[
+         "Fabulae"
+      ]
+   },
+   "LAT1266":{
+      "author":"Hyginus Gromaticus",
+      "works":[
+         "De Limitibus",
+         "De Condicionibus Agrorum",
+         "De Generibus Controversiarum",
+         "Constitutio Limitum [sp.]",
+         "De Munition. Castrorum [sp.]"
+      ]
+   },
+   "LAT1276":{
+      "author":"D. Iunius Iuvenalis",
+      "works":[
+         "Saturae"
+      ]
+   },
+   "LAT1279":{
+      "author":"Laelius Felix",
+      "works":[
+         "iurisprudentia, fragmenta"
+      ]
+   },
+   "LAT1282":{
+      "author":"Lentulus",
+      "works":[
+         "mimus"
+      ]
+   },
+   "LAT1285":{
+      "author":"L. Volusius Maecianus",
+      "works":[
+         "Assis Distributio ..."
+      ]
+   },
+   "LAT1291":{
+      "author":"Marianus",
+      "works":[
+         "Lupercalia"
+      ]
+   },
+   "LAT1294":{
+      "author":"M. Valerius Martialis",
+      "works":[
+         "Spectacula",
+         "Epigrammata"
+      ]
+   },
+   "LAT1297":{
+      "author":"Marullus",
+      "works":[
+         "mimi"
+      ]
+   },
+   "LAT1306":{
+      "author":"L. Neratius Priscus",
+      "works":[
+         "fr. in fragmentis Vaticanis"
+      ]
+   },
+   "LAT1318":{
+      "author":"C. Plinius Caecilius Secundus",
+      "works":[
+         "Epistulae",
+         "Panegyricus",
+         "versus"
+      ]
+   },
+   "LAT1321":{
+      "author":"Sex. Pomponius",
+      "works":[
+         "Liber Regularum, fragmentum"
+      ]
+   },
+   "LAT1327":{
+      "author":"Sabidius",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT1336":{
+      "author":"Scaevus Memor",
+      "works":[
+         "tragoediae"
+      ]
+   },
+   "LAT1339":{
+      "author":"Septimius Serenus",
+      "works":[
+         "carmen"
+      ]
+   },
+   "LAT1342":{
+      "author":"Siculus Flaccus",
+      "works":[
+         "De Condicionibus Agrorum"
+      ]
+   },
+   "LAT1345":{
+      "author":"Silius Italicus",
+      "works":[
+         "Punica"
+      ]
+   },
+   "LAT1348":{
+      "author":"C. Suetonius Tranquillus",
+      "works":[
+         "De Vita Caesarum",
+         "De Poetis",
+         "De Historicis",
+         "De Grammaticis et Rhetoribus",
+         "Prata",
+         "fragmenta"
+      ]
+   },
+   "LAT1351":{
+      "author":"Cornelius Tacitus",
+      "works":[
+         "De Vita Iulii Agricolae",
+         "De Origine et Situ Germanorum",
+         "Dialogus de Oratoribus",
+         "Historiae",
+         "Annales"
+      ]
+   },
+   "LAT1357":{
+      "author":"Imperator M. Ulpius Traianus",
+      "works":[
+         "Dacica"
+      ]
+   },
+   "LAT1363":{
+      "author":"Aemilius Asper",
+      "works":[
+         "comment. in Ter. Sall. Verg.",
+         "Vergilius"
+      ]
+   },
+   "LAT1370":{
+      "author":"Q. Terentius Scaurus",
+      "works":[
+         "De Orthographia",
+         "De Adverbio et Praeposit.",
+         "fr. in codice Parisino 7520",
+         "De ordinat. part. orat. [sp.]"
+      ]
+   },
+   "LAT1374":{
+      "author":"Velius Longus",
+      "works":[
+         "De Orthographia"
+      ]
+   },
+   "LAT1377":{
+      "author":"Fragmenta Bobiensia",
+      "works":[
+         "De Littera",
+         "De Accentibus",
+         "De Propriis Nominibus",
+         "De Nomine",
+         "De Versibus",
+         "De Finalibus Syllabis",
+         "De Structuris",
+         "De Metris"
+      ]
+   },
+   "LAT1380":{
+      "author":"Philumenus medicus",
+      "works":[
+         "De medicina, versio Latina"
+      ]
+   },
+   "LAT1500":{
+      "author":"Altercatio Hadriani Augusti et Epicteti Philosophi",
+      "works":[
+         "Altercatio Hadr. et Epicteti"
+      ]
+   },
+   "LAT1506":{
+      "author":"Anonymi Fragmenta de Iure Fisci",
+      "works":[
+         "fragmenta de iure fisci"
+      ]
+   },
+   "LAT1512":{
+      "author":"Pomponius Porphyrio",
+      "works":[
+         "Commentum in Horati Carmina",
+         "Comment. in Hor. Artem Poet.",
+         "Comment. in Hor. Carm. Saec.",
+         "Commentum in Horati Epodos",
+         "Commentum in Horati Sermones",
+         "Commentum in Horati Epistulas",
+         "Vita Horati"
+      ]
+   },
+   "LAT1515":{
+      "author":"Q. Serenus (Sammonicus)",
+      "works":[
+         "Liber Medicinalis",
+         "Liber Medicinalis, capitula"
+      ]
+   },
+   "LAT1518":{
+      "author":"Terentianus Maurus",
+      "works":[
+         "De Litt., De Syll., De Metr."
+      ]
+   },
+   "LAT1604":{
+      "author":"Iulius Atherianus",
+      "works":[
+         "historiae"
+      ]
+   },
+   "LAT1672":{
+      "author":"Iulius Valerius",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT1908":{
+      "author":"Gallus Antipater",
+      "works":[
+         "historiae"
+      ]
+   },
+   "LAT2000":{
+      "author":"Ablabius",
+      "works":[
+         "epigramma"
+      ]
+   },
+   "LAT2002":{
+      "author":"Albinus",
+      "works":[
+         "Rerum Romanarum Liber I",
+         "De Metris"
+      ]
+   },
+   "LAT2003":{
+      "author":"Caelius Apicius",
+      "works":[
+         "De Re Coquinaria",
+         "Brevis Ciborum, excerpta",
+         "Brevis Pimentorum, excerpta"
+      ]
+   },
+   "LAT2028":{
+      "author":"Chalcidius",
+      "works":[
+         "Ex Graecis Conversiones"
+      ]
+   },
+   "LAT2097":{
+      "author":"Sex. Paconianus",
+      "works":[
+         "carmen"
+      ]
+   },
+   "LAT2123":{
+      "author":"Publilius Optatianus Porfyrius",
+      "works":[
+         "Epigrammata"
+      ]
+   },
+   "LAT2150":{
+      "author":"Zeno of Verona",
+      "works":[
+         "Tractatus"
+      ]
+   },
+   "LAT2300":{
+      "author":"Aemilius Sura",
+      "works":[
+         "De Annis Populi Romani"
+      ]
+   },
+   "LAT2301":{
+      "author":"Q. Aurelius Memmius Symmachus",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT2302":{
+      "author":"L. Aurelius Avianius Symmachus",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT2305":{
+      "author":"Caelius Aurelianus",
+      "works":[
+         "E Parmenide de natura"
+      ]
+   },
+   "LAT2331":{
+      "author":"Scriptores Historiae Augustae",
+      "works":[
+         "[2Aelii]2 Spartiani De Vita Hadriani",
+         "[2Aelii]2 Spartiani Aelius",
+         "Iuli Capitolini Antoninus Pius",
+         "Vita Marci Antonini Philosophi Iuli Capitolini",
+         "Iuli Capitolini Verus",
+         "Avidius [2Cassius]2 Vulcacii Gallicani V.C.",
+         "[2Commodus]2 Antoninus Aeli Lampridi",
+         "[2Helvius]2 Pertinax Iuli Capitolini",
+         "Didius Iulianus Aeli Spartiani",
+         "Aeli Spartiani Severus",
+         "Pescennius Niger [2Aeli Spartiani]2",
+         "Vita Clodii Albini Iulii Capitolini",
+         "Antoninus Caracallus [2Aeli Spartiani]2",
+         "Antoninus Geta [2Aeli Spartiani]2",
+         "Opilius Macrinus Iuli Capitolini",
+         "Diadumenus Antoninus [2Aelii]2 Lampridii",
+         "Aeli Lampridii Antoninus Heliogabalus",
+         "Alexander Severus Aeli Lampridii",
+         "Maximini Duo Iuli Capitolini",
+         "Gordian[2i Tr]2es [2Iuli Capitolini]2",
+         "Maximus [2et Balbinus Iuli Capitolini]2",
+         "[2Trebelli Pollionis]2 Valeriani Duo",
+         "[2Trebelli Pollionis]2 Gallieni Duo",
+         "[2Trebelli Pollionis]2 Tyranni Triginta",
+         "[2Trebelli Pollionis]2 Divus Claudius",
+         "Flavi Vopisci Syracusii Divus Aurelianus",
+         "[2Flavi Vopisci Syracusii]2 Tacitus",
+         "[2Flavi Vopisci Syracusii]2 Probus",
+         "[2Flavi Vopisci Syracusii]2 Quadrigae Tyrannorum",
+         "[2Flavi Vopisci Syracusii]2 Carus et Cari[2nus]2 et Numerianus"
+      ]
+   },
+   "LAT2335":{
+      "author":"Anonymi de Differentiis",
+      "works":[
+         "De Differentiis"
+      ]
+   },
+   "LAT2349":{
+      "author":"Maurus Servius Honoratus",
+      "works":[
+         "De Centum Metris",
+         "Commentarius in Artem Donati",
+         "De Finalibus",
+         "De Metris Horatianis",
+         "In Vergilii Aeneidos Libros",
+         "In Vergilii Bucolicon Librum",
+         "In Vergilii Georgicon Libros"
+      ]
+   },
+   "LAT2434":{
+      "author":"Hilarius Arelatensis",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT2456":{
+      "author":"Parthenius Presbyter",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT2468":{
+      "author":"Aurelius Augustinus",
+      "works":[
+         "Laus Cerei"
+      ]
+   },
+   "LAT2806":{
+      "author":"Iustinianus",
+      "works":[
+         "Digesta Iustiniani"
+      ]
+   },
+   "LAT3211":{
+      "author":"Argumenta Aeneidis et Tetrasticha in cunctis libris Vergilii",
+      "works":[
+         "Argumenta Aeneidis, Decasticha",
+         "Argumenta Aeneidis, Monosticha",
+         "Tetrasticha in Vergilii Bucolica et Georgica",
+         "Tetrasticha in Vergilii Aeneida"
+      ]
+   },
+   "LAT9221":{
+      "author":"Paulus Quaestor",
+      "works":[
+         "carmina"
+      ]
+   },
+   "LAT9254":{
+      "author":"Titius",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT9500":{
+      "author":"Anonymi Epici et Lyrici",
+      "works":[
+         "carmen Saliare",
+         "versus sacrorum",
+         "sententia",
+         "A. Atilii Calatini elogium",
+         "carmen Priami",
+         "saturnius(?)",
+         "Acilii Glabrionis tabula",
+         "M. Aemilii cos. a. 179 tabula",
+         "versiculi populares et pueriles",
+         "praecepta rustica et medica",
+         "epigramma a Varrone Plauto attributum",
+         "epigramma Pacuvi",
+         "Ardeatis templi inscriptio",
+         "templi Tarracinensis inscriptio",
+         "in Carbonem versus popularis",
+         "carmina Marciana et similia",
+         "versus populares in Caesarem et similia",
+         "epigrammata et populares versus in Augustum",
+         "obtrectatoris Vergilii versiculus",
+         "de Crassitio epigramma",
+         "populares versus in Sarmentum",
+         "versus populares in Tiberium et Germanicum",
+         "populares versus in Caligulam",
+         "artificia metrica",
+         "versus populares in Neronem et eiusque successores",
+         "versus Hor. Sat. I 10 praemissi",
+         "versus de VII sapientibus",
+         "odarium",
+         "versus fortasse Clementis(?)",
+         "versus in Caesares Romanos ex Historia Augusta",
+         "versus Orphici ab Arnobio conversi",
+         "Tarentinus senarius",
+         "De Venere et Amoribus",
+         "De Metris",
+         "versus fortasse Enniani",
+         "versus fortasse Luciliani",
+         "versus aevi Catulliani",
+         "versus aevi Catulliani a Morel omissi",
+         "versus aevi Augustei",
+         "serioris aetatis versus",
+         "versus reciproci"
+      ]
+   },
+   "LAT9505":{
+      "author":"Anonymi Comici et Tragici",
+      "works":[
+         "Togatae Poetarum Incertorum",
+         "Atellanae Poetarum Incertorum",
+         "Palliatae Poetarum Incertorum",
+         "Tragoediae Poetarum Incertorum"
+      ]
+   },
+   "LAT9510":{
+      "author":"Anonymi Grammatici",
+      "works":[
+         "grammatica"
+      ]
+   },
+   "LAT9969":{
+      "author":"Vita Iuvenalis",
+      "works":[
+         "Vita Iuvenalis"
+      ]
+   }
+}


### PR DESCRIPTION
Don't know it this is useful, I processed every .idt file of phi and made a dictionary with id label (LAT0023) as key and {"author":"name", "works":["work1", "work2"]}.

Please see if it's ok or a better structure is needed