### PR TITLE
fixed beta codes in strings, mostly [2 and ]2 to [ and ]

### DIFF
--- a/cltk/corpus/latin/phi/phi_index.json
+++ b/cltk/corpus/latin/phi/phi_index.json
@@ -2504,7 +2504,7 @@
             ]
          },
          "002":{
-            "name":"elegia in pap. Qas%1r Ibri=m",
+            "name":"elegia in pap. Qaṣr Ibrîm",
             "reference":[
                "column",
                "verse"
@@ -6930,7 +6930,7 @@
       "author":"Scriptores Historiae Augustae",
       "works":{
          "001":{
-            "name":"[2Aelii]2 Spartiani De Vita Hadriani",
+            "name":"[Aelii] Spartiani De Vita Hadriani",
             "reference":[
                "chapter",
                "section",
@@ -6938,7 +6938,7 @@
             ]
          },
          "002":{
-            "name":"[2Aelii]2 Spartiani Aelius",
+            "name":"[Aelii] Spartiani Aelius",
             "reference":[
                "chapter",
                "section",
@@ -6970,7 +6970,7 @@
             ]
          },
          "006":{
-            "name":"Avidius [2Cassius]2 Vulcacii Gallicani V.C.",
+            "name":"Avidius [Cassius] Vulcacii Gallicani V.C.",
             "reference":[
                "chapter",
                "section",
@@ -6978,7 +6978,7 @@
             ]
          },
          "007":{
-            "name":"[2Commodus]2 Antoninus Aeli Lampridi",
+            "name":"[Commodus] Antoninus Aeli Lampridi",
             "reference":[
                "chapter",
                "section",
@@ -6986,7 +6986,7 @@
             ]
          },
          "008":{
-            "name":"[2Helvius]2 Pertinax Iuli Capitolini",
+            "name":"[Helvius] Pertinax Iuli Capitolini",
             "reference":[
                "chapter",
                "section",
@@ -7010,7 +7010,7 @@
             ]
          },
          "011":{
-            "name":"Pescennius Niger [2Aeli Spartiani]2",
+            "name":"Pescennius Niger [Aeli Spartiani]",
             "reference":[
                "chapter",
                "section",
@@ -7026,7 +7026,7 @@
             ]
          },
          "013":{
-            "name":"Antoninus Caracallus [2Aeli Spartiani]2",
+            "name":"Antoninus Caracallus [Aeli Spartiani]",
             "reference":[
                "chapter",
                "section",
@@ -7034,7 +7034,7 @@
             ]
          },
          "014":{
-            "name":"Antoninus Geta [2Aeli Spartiani]2",
+            "name":"Antoninus Geta [Aeli Spartiani]",
             "reference":[
                "chapter",
                "section",
@@ -7050,7 +7050,7 @@
             ]
          },
          "016":{
-            "name":"Diadumenus Antoninus [2Aelii]2 Lampridii",
+            "name":"Diadumenus Antoninus [Aelii] Lampridii",
             "reference":[
                "chapter",
                "section",
@@ -7082,7 +7082,7 @@
             ]
          },
          "020":{
-            "name":"Gordian[2i Tr]2es [2Iuli Capitolini]2",
+            "name":"Gordian[i Tr]es [Iuli Capitolini]",
             "reference":[
                "chapter",
                "section",
@@ -7090,7 +7090,7 @@
             ]
          },
          "021":{
-            "name":"Maximus [2et Balbinus Iuli Capitolini]2",
+            "name":"Maximus [et Balbinus Iuli Capitolini]",
             "reference":[
                "chapter",
                "section",
@@ -7098,7 +7098,7 @@
             ]
          },
          "022":{
-            "name":"[2Trebelli Pollionis]2 Valeriani Duo",
+            "name":"[Trebelli Pollionis] Valeriani Duo",
             "reference":[
                "chapter",
                "section",
@@ -7106,7 +7106,7 @@
             ]
          },
          "023":{
-            "name":"[2Trebelli Pollionis]2 Gallieni Duo",
+            "name":"[Trebelli Pollionis] Gallieni Duo",
             "reference":[
                "chapter",
                "section",
@@ -7114,7 +7114,7 @@
             ]
          },
          "024":{
-            "name":"[2Trebelli Pollionis]2 Tyranni Triginta",
+            "name":"[Trebelli Pollionis] Tyranni Triginta",
             "reference":[
                "chapter",
                "section",
@@ -7122,7 +7122,7 @@
             ]
          },
          "025":{
-            "name":"[2Trebelli Pollionis]2 Divus Claudius",
+            "name":"[Trebelli Pollionis] Divus Claudius",
             "reference":[
                "chapter",
                "section",
@@ -7138,7 +7138,7 @@
             ]
          },
          "027":{
-            "name":"[2Flavi Vopisci Syracusii]2 Tacitus",
+            "name":"[Flavi Vopisci Syracusii] Tacitus",
             "reference":[
                "chapter",
                "section",
@@ -7146,7 +7146,7 @@
             ]
          },
          "028":{
-            "name":"[2Flavi Vopisci Syracusii]2 Probus",
+            "name":"[Flavi Vopisci Syracusii] Probus",
             "reference":[
                "chapter",
                "section",
@@ -7154,7 +7154,7 @@
             ]
          },
          "029":{
-            "name":"[2Flavi Vopisci Syracusii]2 Quadrigae Tyrannorum",
+            "name":"[Flavi Vopisci Syracusii] Quadrigae Tyrannorum",
             "reference":[
                "chapter",
                "section",
@@ -7162,7 +7162,7 @@
             ]
          },
          "030":{
-            "name":"[2Flavi Vopisci Syracusii]2 Carus et Cari[2nus]2 et Numerianus",
+            "name":"[Flavi Vopisci Syracusii] Carus et Cari[nus] et Numerianus",
             "reference":[
                "chapter",
                "section",


### PR DESCRIPTION
Fixed beta codes in strings used to encode editorial signs like "[" and "]"